### PR TITLE
Limit leaderboard to top 50

### DIFF
--- a/loadCurrentLeaderboardStandings.py
+++ b/loadCurrentLeaderboardStandings.py
@@ -23,7 +23,7 @@ def main():
     mapped['frameCount'] = e.numFrames.value
     return mapped
 
-  mappedEntities = list(map(mapper, entityList))
+  mappedEntities = list(map(mapper, entityList))[:50]
   
   lastRunTime = datetime.now()
   if os.path.isfile('src/data/current.json'):


### PR DESCRIPTION
Limit the array of returned fastest roadmaps to the fastest 50, sorted by frameCount.